### PR TITLE
mcs make bucket api remove setting access policy

### DIFF
--- a/models/make_bucket_request.go
+++ b/models/make_bucket_request.go
@@ -34,9 +34,6 @@ import (
 // swagger:model makeBucketRequest
 type MakeBucketRequest struct {
 
-	// access
-	Access BucketAccess `json:"access,omitempty"`
-
 	// name
 	// Required: true
 	Name *string `json:"name"`
@@ -46,10 +43,6 @@ type MakeBucketRequest struct {
 func (m *MakeBucketRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAccess(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateName(formats); err != nil {
 		res = append(res, err)
 	}
@@ -57,22 +50,6 @@ func (m *MakeBucketRequest) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *MakeBucketRequest) validateAccess(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.Access) { // not required
-		return nil
-	}
-
-	if err := m.Access.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("access")
-		}
-		return err
-	}
-
 	return nil
 }
 

--- a/restapi/client-admin.go
+++ b/restapi/client-admin.go
@@ -18,12 +18,13 @@ package restapi
 
 import (
 	"context"
-	mcCmd "github.com/minio/mc/cmd"
-	"github.com/minio/mc/pkg/probe"
-	"github.com/minio/minio/pkg/madmin"
 	"io"
 	"path/filepath"
 	"runtime"
+
+	mcCmd "github.com/minio/mc/cmd"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 const globalAppName = "mcs"

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -31,7 +31,6 @@ func init() {
 	minio.MaxRetry = 1
 }
 
-
 // Define MinioClient interface with all functions to be implemented
 // by mock when testing, it should include all MinioClient respective api calls
 // that are used within this project.

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1317,9 +1317,6 @@ func init() {
         "name"
       ],
       "properties": {
-        "access": {
-          "$ref": "#/definitions/bucketAccess"
-        },
         "name": {
           "type": "string"
         }
@@ -2855,9 +2852,6 @@ func init() {
         "name"
       ],
       "properties": {
-        "access": {
-          "$ref": "#/definitions/bucketAccess"
-        },
         "name": {
           "type": "string"
         }

--- a/restapi/user_buckets_test.go
+++ b/restapi/user_buckets_test.go
@@ -112,49 +112,21 @@ func TestMakeBucket(t *testing.T) {
 	minClient := minioClientMock{}
 	function := "makeBucket()"
 	ctx := context.Background()
-	// Test-1: makeBucket() create a bucket with public access
+	// Test-1: makeBucket() create a bucket
 	// mock function response from makeBucketWithContext(ctx)
 	minioMakeBucketWithContextMock = func(ctx context.Context, bucketName, location string) error {
 		return nil
 	}
-	// mock function response from setBucketPolicyWithContext(ctx)
-	minioSetBucketPolicyWithContextMock = func(ctx context.Context, bucketName, policy string) error {
-		return nil
-	}
-	if err := makeBucket(ctx, minClient, "bucktest1", models.BucketAccessPUBLIC); err != nil {
+	if err := makeBucket(ctx, minClient, "bucktest1"); err != nil {
 		t.Errorf("Failed on %s:, error occurred: %s", function, err.Error())
 	}
 
-	// Test-2: makeBucket() create a bucket with private access
-	if err := makeBucket(ctx, minClient, "bucktest1", models.BucketAccessPRIVATE); err != nil {
-		t.Errorf("Failed on %s:, error occurred: %s", function, err.Error())
-	}
-
-	// Test-3: makeBucket() create a bucket with an invalid access, expected error
-	if err := makeBucket(ctx, minClient, "bucktest1", "other"); assert.Error(err) {
-		assert.Equal("bucket created but error occurred while setting policy: access: `other` not supported", err.Error())
-	}
-
-	// Test-4 makeBucket() make sure errors are handled correctly when error on MakeBucketWithContext
+	// Test-2 makeBucket() make sure errors are handled correctly when error on MakeBucketWithContext
 	minioMakeBucketWithContextMock = func(ctx context.Context, bucketName, location string) error {
 		return errors.New("error")
 	}
-	minioSetBucketPolicyWithContextMock = func(ctx context.Context, bucketName, policy string) error {
-		return nil
-	}
-	if err := makeBucket(ctx, minClient, "bucktest1", models.BucketAccessPUBLIC); assert.Error(err) {
+	if err := makeBucket(ctx, minClient, "bucktest1"); assert.Error(err) {
 		assert.Equal("error", err.Error())
-	}
-
-	// Test-5 makeBucket() make sure errors are handled correctly when error on SetBucketPolicyWithContext
-	minioMakeBucketWithContextMock = func(ctx context.Context, bucketName, location string) error {
-		return nil
-	}
-	minioSetBucketPolicyWithContextMock = func(ctx context.Context, bucketName, policy string) error {
-		return errors.New("error")
-	}
-	if err := makeBucket(ctx, minClient, "bucktest1", models.BucketAccessPUBLIC); assert.Error(err) {
-		assert.Equal("bucket created but error occurred while setting policy: error", err.Error())
 	}
 }
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -684,8 +684,6 @@ definitions:
     properties:
       name:
         type: string
-      access:
-        $ref: "#/definitions/bucketAccess"
   error:
     type: object
     required:


### PR DESCRIPTION
This pr removes setting policy on make bucket api since if it fails setting the policy, the bucket can remain created. Also this is more how minio/mc works.