### PR TITLE
TLS redirect enabled by default

### DIFF
--- a/cmd/mcs/server.go
+++ b/cmd/mcs/server.go
@@ -120,6 +120,7 @@ func startServer(ctx *cli.Context) error {
 		// Need to store tls-port, tls-host un config variables so secure.middleware can read from there
 		restapi.TLSPort = fmt.Sprintf("%v",ctx.Int("tls-port"))
 		restapi.TLSHostname = ctx.String("tls-host")
+		restapi.TLSRedirect = "on"
 	}
 
 	server.ConfigureAPI()

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -28,6 +28,7 @@ var Port = "9090"
 var Hostname = "localhost"
 var TLSHostname = "localhost"
 var TLSPort = "9443"
+var TLSRedirect = "off"
 
 func getAccessKey() string {
 	return env.Get(McsAccessKey, "minioadmin")
@@ -147,7 +148,7 @@ func getSecureHostsProxyHeaders() []string {
 
 // If SSLRedirect is set to true, then only allow HTTPS requests. Default is true.
 func getSSLRedirect() bool {
-	return strings.ToLower(env.Get(McsSecureSSLRedirect, "off")) == "on"
+	return strings.ToLower(env.Get(McsSecureSSLRedirect, TLSRedirect)) == "on"
 }
 
 // SSLHost is the host name that is used to redirect HTTP requests to HTTPS. Default is "", which indicates to use the same host.


### PR DESCRIPTION
When certificates are provided to mcs, tls direct will be
enabled by default (http://localhost -> https:localhost), you
can change this behavior by providing the `MCS_SECURE_SSL_REDIRECT=off`
env variable