### PR TITLE
UI remove setting access on make bucket and custom option on set access to bucket

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket.tsx
@@ -49,29 +49,26 @@ interface IAddBucketProps {
 interface IAddBucketState {
   addLoading: boolean;
   addError: string;
-  bucketName: string;
-  accessPolicy: string;
+  bucketName: string; 
 }
 
 class AddBucket extends React.Component<IAddBucketProps, IAddBucketState> {
   state: IAddBucketState = {
     addLoading: false,
     addError: "",
-    bucketName: "",
-    accessPolicy: ""
+    bucketName: ""
   };
 
   addRecord(event: React.FormEvent) {
     event.preventDefault();
-    const { bucketName, addLoading, accessPolicy } = this.state;
+    const { bucketName, addLoading } = this.state;
     if (addLoading) {
       return;
     }
     this.setState({ addLoading: true }, () => {
       api
         .invoke("POST", "/api/v1/buckets", {
-          name: bucketName,
-          access: accessPolicy
+          name: bucketName
         })
         .then(res => {
           this.setState(
@@ -95,7 +92,7 @@ class AddBucket extends React.Component<IAddBucketProps, IAddBucketState> {
 
   render() {
     const { classes, open } = this.props;
-    const { addLoading, addError, accessPolicy } = this.state;
+    const { addLoading, addError} = this.state;
     return (
       <Dialog
         open={open}
@@ -141,25 +138,7 @@ class AddBucket extends React.Component<IAddBucketProps, IAddBucketState> {
                 />
               </Grid>
               <Grid item xs={12}>
-                <FormControl className={classes.formControl} fullWidth>
-                  <InputLabel id="select-access-policy">
-                    Access Policy
-                  </InputLabel>
-                  <Select
-                    labelId="select-access-policy"
-                    id="select-access-policy"
-                    value={accessPolicy}
-                    onChange={(e: React.ChangeEvent<{ value: unknown }>) => {
-                      this.setState({ accessPolicy: e.target.value as string });
-                    }}
-                  >
-                    <MenuItem value="PRIVATE">Private</MenuItem>
-                    <MenuItem value="PUBLIC">Public</MenuItem>
-                    <MenuItem value="CUSTOM">Custom</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
+                <br />
                 <br />
               </Grid>
               <Grid item xs={12}>

--- a/portal-ui/src/screens/Console/Buckets/ViewBucket/SetAccessPolicy.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ViewBucket/SetAccessPolicy.tsx
@@ -145,7 +145,6 @@ class SetAccessPolicy extends React.Component<
                   >
                     <MenuItem value="PRIVATE">Private</MenuItem>
                     <MenuItem value="PUBLIC">Public</MenuItem>
-                    <MenuItem value="CUSTOM">Custom</MenuItem>
                   </Select>
                 </FormControl>
               </Grid>


### PR DESCRIPTION
- UI remove setting access on make bucket
- Also Remove CUSTOM option on access to set since we don't support CUSTOM yet.

To test this 
1. Go to buckets tab and click on `CREATE BUCKET`
     - only the bucket name should be required

Second change:
1. Go to buckets tab and click on one bucket 
2. Click on `Change Access Policy`
     - only Private and Public options should be available
<img width="335" alt="Screen Shot 2020-04-07 at 11 40 56 AM" src="https://user-images.githubusercontent.com/11819101/78709030-dbd1b480-78c7-11ea-85ce-d55c38bcb566.png">
<img width="285" alt="Screen Shot 2020-04-07 at 11 59 13 AM" src="https://user-images.githubusercontent.com/11819101/78709041-de340e80-78c7-11ea-93d9-495b03ff22b7.png">

