### PR TITLE
Creation of reusable components for mcs & implementation in users page

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ER
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-bindata/go-bindata v3.1.2+incompatible h1:5vjJMVhowQdPzjE1LdxyFF7YFTXg5IgGVW4gBr5IbvE=
 github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=

--- a/portal-ui/public/index.html
+++ b/portal-ui/public/index.html
@@ -12,7 +12,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-      <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
+      <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700;900&display=swap" rel="stylesheet">
       <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-icon-180x180.png">
       <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
       <link rel="icon" type="image/png" sizes="96x96" href="%PUBLIC_URL%/favicon-96x96.png">

--- a/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
@@ -1,0 +1,108 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import React from "react";
+import { TextField, Grid, InputLabel, TextFieldProps } from "@material-ui/core";
+import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
+import {
+  createStyles,
+  makeStyles,
+  Theme,
+  withStyles
+} from "@material-ui/core/styles";
+import { fieldBasic } from "../common/styleLibrary";
+
+interface InputBoxProps {
+  label: string;
+  classes: any;
+  onChangeFunc: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  id: string;
+  name: string;
+  disabled?: boolean;
+  type?: string;
+  autoComplete?: string;
+}
+
+const styles = (theme: Theme) =>
+  createStyles({
+    ...fieldBasic,
+    textBoxContainer: {
+      flexGrow: 1
+    }
+  });
+
+const inputStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      borderColor: "#393939",
+      borderRadius: 0
+    },
+    input: {
+      padding: "11px 20px",
+      color: "#393939",
+      fontSize: 14
+    }
+  })
+);
+
+function InputField(props: TextFieldProps) {
+  const classes = inputStyles();
+
+  return (
+    <TextField
+      InputProps={{ classes } as Partial<OutlinedInputProps>}
+      {...props}
+    />
+  );
+}
+
+const InputBoxWrapper = ({
+  label,
+  onChangeFunc,
+  value,
+  id,
+  name,
+  type = "text",
+  autoComplete = "off",
+  disabled = false,
+  classes
+}: InputBoxProps) => {
+  return (
+    <React.Fragment>
+      <Grid item xs={12} className={classes.fieldContainer}>
+        <InputLabel htmlFor={id} className={classes.inputLabel}>
+          {label}
+        </InputLabel>
+        <div className={classes.textBoxContainer}>
+          <InputField
+            className={classes.boxDesign}
+            id={id}
+            name={name}
+            variant="outlined"
+            fullWidth
+            value={value}
+            disabled={disabled}
+            onChange={onChangeFunc}
+            type={type}
+            autoComplete={autoComplete}
+          />
+        </div>
+      </Grid>
+    </React.Fragment>
+  );
+};
+
+export default withStyles(styles)(InputBoxWrapper);

--- a/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
@@ -1,0 +1,143 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import React from "react";
+import Grid from "@material-ui/core/Grid";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio, { RadioProps } from "@material-ui/core/Radio";
+import { InputLabel } from "@material-ui/core";
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  makeStyles
+} from "@material-ui/core/styles";
+import { fieldBasic } from "../common/styleLibrary";
+
+interface selectorTypes {
+  label: string;
+  value: string;
+}
+
+interface RadioGroupProps {
+  selectorOptions: selectorTypes[];
+  currentSelection: string;
+  label: string;
+  id: string;
+  name: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  classes: any;
+  displayInColumn?: boolean;
+}
+
+const styles = (theme: Theme) =>
+  createStyles({
+    ...fieldBasic,
+    radioBoxContainer: {
+      flexGrow: 1
+    }
+  });
+
+const radioStyles = makeStyles({
+  root: {
+    "&:hover": {
+      backgroundColor: "transparent"
+    }
+  },
+  icon: {
+    borderRadius: "100%",
+    width: 14,
+    height: 14,
+    border: "1px solid #000"
+  },
+  checkedIcon: {
+    borderRadius: "100%",
+    width: 14,
+    height: 14,
+    border: "1px solid #000",
+    padding: 4,
+    position: "relative",
+    "&::after": {
+      content: '" "',
+      width: 8,
+      height: 8,
+      borderRadius: "100%",
+      display: "block",
+      position: "absolute",
+      backgroundColor: "#000",
+      top: 2,
+      left: 2
+    }
+  }
+});
+
+const RadioButton = (props: RadioProps) => {
+  const classes = radioStyles();
+
+  return (
+    <Radio
+      className={classes.root}
+      disableRipple
+      color="default"
+      checkedIcon={<span className={classes.checkedIcon} />}
+      icon={<span className={classes.icon} />}
+      {...props}
+    />
+  );
+};
+
+export const RadioGroupSelector = ({
+  selectorOptions = [],
+  currentSelection,
+  label,
+  id,
+  name,
+  onChange,
+  classes,
+  displayInColumn = false
+}: RadioGroupProps) => {
+  return (
+    <React.Fragment>
+      <Grid item xs={12} className={classes.fieldContainer}>
+        <InputLabel htmlFor={id} className={classes.inputLabel}>
+          {label}
+        </InputLabel>
+        <div className={classes.radioBoxContainer}>
+          <RadioGroup
+            aria-label={id}
+            id={id}
+            name={name}
+            value={currentSelection}
+            onChange={onChange}
+            row={!displayInColumn}
+          >
+            {selectorOptions.map(selectorOption => {
+              return (
+                <FormControlLabel
+                  value={selectorOption.value}
+                  control={<RadioButton />}
+                  label={selectorOption.label}
+                />
+              );
+            })}
+          </RadioGroup>
+        </div>
+      </Grid>
+    </React.Fragment>
+  );
+};
+
+export default withStyles(styles)(RadioGroupSelector);

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -1,0 +1,31 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// This object contains variables that will be used across form components.
+export const fieldBasic = {
+  inputLabel: {
+    fontWeight: 500,
+    marginRight: 16,
+    minWidth: 80,
+    fontSize: 14,
+    color: "#393939"
+  },
+  fieldContainer: {
+    display: "flex",
+    alignItems: "center",
+    marginBottom: 10
+  }
+};

--- a/portal-ui/src/screens/Console/Common/ModalWrapper/ModalWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/ModalWrapper/ModalWrapper.tsx
@@ -1,0 +1,125 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+import { Dialog, DialogContent, DialogTitle } from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
+import CloseIcon from "@material-ui/icons/Close";
+import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+
+interface IModalProps {
+  classes: any;
+  closeModalAndRefresh: () => void;
+  modalOpen: boolean;
+  title: string;
+  children: any;
+}
+
+const baseCloseLine = {
+  content: '" "',
+  borderLeft: "2px solid #707070",
+  height: 33,
+  width: 1,
+  position: "absolute"
+};
+
+const styles = (theme: Theme) =>
+  createStyles({
+    dialogContainer: {
+      padding: "12px 26px 22px"
+    },
+    closeContainer: {
+      textAlign: "right"
+    },
+    closeButton: {
+      width: 45,
+      height: 45,
+      padding: 0,
+      backgroundColor: "initial",
+      "&:hover": {
+        backgroundColor: "initial"
+      },
+      "&:active": {
+        backgroundColor: "initial"
+      }
+    },
+    modalCloseIcon: {
+      fontSize: 35,
+      color: "#707070",
+      fontWeight: 300,
+      "&:hover": {
+        color: "#000"
+      }
+    },
+    closeIcon: {
+      "&::before": {
+        ...baseCloseLine,
+        transform: "rotate(45deg)"
+      },
+      "&::after": {
+        ...baseCloseLine,
+        transform: "rotate(-45deg)"
+      },
+      "&:hover::before, &:hover::after": {
+        borderColor: "#000"
+      },
+      width: 24,
+      height: 24,
+      display: "block",
+      position: "relative"
+    },
+    titleClass: {
+      padding: "0px 24px 12px"
+    }
+  });
+
+const ModalWrapper = ({
+  closeModalAndRefresh,
+  modalOpen,
+  title,
+  children,
+  classes
+}: IModalProps) => {
+  return (
+    <Dialog
+      open={modalOpen}
+      onClose={closeModalAndRefresh}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      maxWidth={"md"}
+      fullWidth
+    >
+      <div className={classes.dialogContainer}>
+        <div className={classes.closeContainer}>
+          <IconButton
+            aria-label="close"
+            className={classes.closeButton}
+            onClick={closeModalAndRefresh}
+            disableRipple
+          >
+            <span className={classes.closeIcon} />
+          </IconButton>
+        </div>
+        <DialogTitle id="alert-dialog-title" className={classes.titleClass}>
+          {title}
+        </DialogTitle>
+        <DialogContent>{children}</DialogContent>
+      </div>
+    </Dialog>
+  );
+};
+
+export default withStyles(styles)(ModalWrapper);

--- a/portal-ui/src/screens/Console/Groups/UsersSelectors.tsx
+++ b/portal-ui/src/screens/Console/Groups/UsersSelectors.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useState, useEffect } from "react";
+import get from "lodash/get";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { LinearProgress } from "@material-ui/core";
 import TableContainer from "@material-ui/core/TableContainer";
@@ -86,7 +87,8 @@ const styles = (theme: Theme) =>
       padding: 12,
       borderRadius: 5,
       boxShadow: "0px 3px 6px #00000012",
-      width: "100%"
+      width: "100%",
+      zIndex: 500
     },
     noFound: {
       textAlign: "center",
@@ -96,7 +98,7 @@ const styles = (theme: Theme) =>
       maxHeight: 250
     },
     stickyHeader: {
-      backgroundColor: "transparent"
+      backgroundColor: "#fff"
     }
   });
 
@@ -122,13 +124,15 @@ const UsersSelectors = ({
     }
   }, [loading]);
 
+  const selUsers = !selectedUsers ? [] : selectedUsers;
+
   //Fetch Actions
   const selectionChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     const targetD = e.target;
     const value = targetD.value;
     const checked = targetD.checked;
 
-    let elements: string[] = [...selectedUsers]; // We clone the selectedGroups array
+    let elements: string[] = [...selUsers]; // We clone the selectedGroups array
 
     if (checked) {
       // If the user has checked this field we need to push this to selectedGroupsList
@@ -146,7 +150,13 @@ const UsersSelectors = ({
     api
       .invoke("GET", `/api/v1/users`)
       .then((res: UsersList) => {
-        setRecords(res.users.sort(usersSort));
+        let users = get(res, "users", []);
+
+        if (!users) {
+          users = [];
+        }
+
+        setRecords(users.sort(usersSort));
         setError("");
         isLoading(false);
       })
@@ -211,7 +221,7 @@ const UsersSelectors = ({
                               "aria-label": "secondary checkbox"
                             }}
                             onChange={selectionChanged}
-                            checked={selectedUsers.includes(row.accessKey)}
+                            checked={selUsers.includes(row.accessKey)}
                           />
                         </TableCell>
                         <TableCell className={classes.wrapCell}>

--- a/portal-ui/src/screens/Console/Users/GroupsSelectors.tsx
+++ b/portal-ui/src/screens/Console/Users/GroupsSelectors.tsx
@@ -33,6 +33,7 @@ import Checkbox from "@material-ui/core/Checkbox";
 import api from "../../../common/api";
 import { groupsSort } from "../../../utils/sortFunctions";
 import { GroupsList } from "../Groups/types";
+import get from "lodash/get";
 
 interface IGroupsProps {
   classes: any;
@@ -88,17 +89,18 @@ const styles = (theme: Theme) =>
       padding: 12,
       borderRadius: 5,
       boxShadow: "0px 3px 6px #00000012",
-      width: "100%"
+      width: "100%",
+      zIndex: 500
     },
     noFound: {
       textAlign: "center",
       padding: "10px 0"
     },
     tableContainer: {
-      maxHeight: 250
+      maxHeight: 200
     },
     stickyHeader: {
-      backgroundColor: "transparent"
+      backgroundColor: "#fff"
     }
   });
 
@@ -124,11 +126,18 @@ const GroupsSelectors = ({
     }
   }, [loading]);
 
+  const selGroups = !selectedGroups ? [] : selectedGroups;
+
   const fetchGroups = () => {
     api
       .invoke("GET", `/api/v1/groups`)
       .then((res: GroupsList) => {
-        setRecords(res.groups.sort(groupsSort));
+        let groups = get(res, "groups", []);
+
+        if (!groups) {
+          groups = [];
+        }
+        setRecords(groups.sort(groupsSort));
         setError("");
         isLoading(false);
       })
@@ -143,7 +152,7 @@ const GroupsSelectors = ({
     const value = targetD.value;
     const checked = targetD.checked;
 
-    let elements: string[] = [...selectedGroups]; // We clone the selectedGroups array
+    let elements: string[] = [...selGroups]; // We clone the selectedGroups array
 
     if (checked) {
       // If the user has checked this field we need to push this to selectedGroupsList
@@ -212,7 +221,7 @@ const GroupsSelectors = ({
                               "aria-label": "secondary checkbox"
                             }}
                             onChange={selectionChanged}
-                            checked={selectedGroups.includes(groupName)}
+                            checked={selGroups.includes(groupName)}
                           />
                         </TableCell>
                         <TableCell className={classes.wrapCell}>

--- a/portal-ui/src/screens/Console/Users/Users.tsx
+++ b/portal-ui/src/screens/Console/Users/Users.tsx
@@ -215,14 +215,24 @@ class Users extends React.Component<IUsersProps, IUsersState> {
 
     return (
       <React.Fragment>
-        <AddUser
-          open={addScreenOpen}
-          selectedUser={selectedUser}
-          closeModalAndRefresh={() => {
-            this.closeAddModalAndRefresh();
-          }}
-        />
-
+        {addScreenOpen && (
+          <AddUser
+            open={addScreenOpen}
+            selectedUser={selectedUser}
+            closeModalAndRefresh={() => {
+              this.closeAddModalAndRefresh();
+            }}
+          />
+        )}
+        {deleteOpen && (
+          <DeleteUser
+            deleteOpen={deleteOpen}
+            selectedUser={selectedUser}
+            closeDeleteModalAndRefresh={(refresh: boolean) => {
+              this.closeDeleteModalAndRefresh(refresh);
+            }}
+          />
+        )}
         <Grid container>
           <Grid item xs={12}>
             <Typography variant="h6">Users</Typography>
@@ -355,13 +365,6 @@ class Users extends React.Component<IUsersProps, IUsersState> {
             </Paper>
           </Grid>
         </Grid>
-        <DeleteUser
-          deleteOpen={deleteOpen}
-          selectedUser={selectedUser}
-          closeDeleteModalAndRefresh={(refresh: boolean) => {
-            this.closeDeleteModalAndRefresh(refresh);
-          }}
-        />
       </React.Fragment>
     );
   }

--- a/restapi/client-admin.go
+++ b/restapi/client-admin.go
@@ -59,6 +59,7 @@ type MinioAdmin interface {
 	addUser(ctx context.Context, acessKey, SecretKey string) error
 	removeUser(ctx context.Context, accessKey string) error
 	getUserInfo(ctx context.Context, accessKey string) (madmin.UserInfo, error)
+	setUserStatus(ctx context.Context, accessKey string, status madmin.AccountStatus) error
 	listGroups(ctx context.Context) ([]string, error)
 	updateGroupMembers(ctx context.Context, greq madmin.GroupAddRemove) error
 	getGroupDescription(ctx context.Context, group string) (*madmin.GroupDesc, error)
@@ -103,6 +104,11 @@ func (ac adminClient) removeUser(ctx context.Context, accessKey string) error {
 //implements madmin.GetUserInfo()
 func (ac adminClient) getUserInfo(ctx context.Context, accessKey string) (madmin.UserInfo, error) {
 	return ac.client.GetUserInfo(ctx, accessKey)
+}
+
+// implements madmin.SetUserStatus()
+func (ac adminClient) setUserStatus(ctx context.Context, accessKey string, status madmin.AccountStatus) error {
+	return ac.client.SetUserStatus(ctx, accessKey, status)
 }
 
 // implements madmin.ListGroups()


### PR DESCRIPTION
## What does this do?

Creation of reusable componentes for mcs:
- ModalWrapper => Modal box component with MinIO styles
- InputBoxWrapper => Input box component with MinIO styles
- RadioGroupSelector => Component that generates a Radio Group Selector combo with the requested options and MinIO styles

Implementation of these new components in users creation / edit components

## How it looks

![Screen Shot 2020-04-10 at 10 12 18 PM](https://user-images.githubusercontent.com/33497058/79034304-925cc000-7b7a-11ea-9ec6-e5bbd8e48938.png)
![Screen Shot 2020-04-10 at 10 12 02 PM](https://user-images.githubusercontent.com/33497058/79034305-92f55680-7b7a-11ea-8f7b-9093a4e1f151.png)

## How to test?

- Go into User page and try to add a new user
- Look at the components specially in modal box & input boxes
- Add the user and check that everything works as usual
- Select the user that you've just added and click on the view button
- In the opened modal you should see the radio combo component implemented
- Change the status of the user as well as change the groups for it
- Click on save, The changes must be saved
- Refresh the page & click on the edit button for the modified user again
- You should see the saved information.