### PR TITLE
Connect MCS with Minio TLS/Custom CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ export MCS_MINIO_SERVER=http://localhost:9000
 ./mcs server
 ```
 
+## Connect MCS to a Minio using TLS and a self-signed certificate
+
+```
+...
+export MCS_MINIO_SERVER_TLS_SKIP_VERIFICATION=on
+export MCS_MINIO_SERVER=https://localhost:9000
+./mcs server
+```
+
 You can verify that the apis work by doing the request on `localhost:9090/api/v1/...`
 
 # Contribute to mcs Project

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/Azure/azure-storage-blob-go v0.8.0 h1:53qhf0Oxa0nOjgbDeeYPUeyiNmafAFE
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
 github.com/Azure/go-autorest v11.7.1+incompatible h1:M2YZIajBBVekV86x0rr1443Lc1F/Ylxb9w+5EtSyX3Q=
 github.com/Azure/go-autorest v11.7.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -48,7 +48,17 @@ func getSecretKey() string {
 }
 
 func getMinIOServer() string {
-	return env.Get(McsMinIOServer, "http://localhost:9000")
+	return strings.TrimSpace(env.Get(McsMinIOServer, "http://localhost:9000"))
+}
+
+// If MCS_MINIO_SERVER_TLS_ROOT_CAS is true mcs will load a list of certificates into the
+// http.client rootCAs store, this is useful for testing or when working with self-signed certificates
+func getMinioServerTLSRootCAs() []string {
+	caCertFileNames := strings.TrimSpace(env.Get(McsMinIOServerTLSRootCAs, ""))
+	if caCertFileNames == "" {
+		return []string{}
+	}
+	return strings.Split(caCertFileNames, ",")
 }
 
 func getMinIOEndpoint() string {
@@ -67,7 +77,7 @@ func getMinIOEndpointIsSecure() bool {
 	if strings.Contains(server, "://") {
 		parts := strings.Split(server, "://")
 		if len(parts) > 1 {
-			if parts[1] == "https" {
+			if parts[0] == "https" {
 				return true
 			}
 		}

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -18,15 +18,16 @@ package restapi
 
 const (
 	// consts for common configuration
-	McsVersion        = `0.1.0`
-	McsAccessKey      = "MCS_ACCESS_KEY"
-	McsSecretKey      = "MCS_SECRET_KEY"
-	McsMinIOServer    = "MCS_MINIO_SERVER"
-	McsProductionMode = "MCS_PRODUCTION_MODE"
-	McsHostname       = "MCS_HOSTNAME"
-	McsPort           = "MCS_PORT"
-	McsTLSHostname    = "MCS_TLS_HOSTNAME"
-	McsTLSPort        = "MCS_TLS_PORT"
+	McsVersion               = `0.1.0`
+	McsAccessKey             = "MCS_ACCESS_KEY"
+	McsSecretKey             = "MCS_SECRET_KEY"
+	McsMinIOServer           = "MCS_MINIO_SERVER"
+	McsMinIOServerTLSRootCAs = "MCS_MINIO_SERVER_TLS_ROOT_CAS"
+	McsProductionMode        = "MCS_PRODUCTION_MODE"
+	McsHostname              = "MCS_HOSTNAME"
+	McsPort                  = "MCS_PORT"
+	McsTLSHostname           = "MCS_TLS_HOSTNAME"
+	McsTLSPort               = "MCS_TLS_PORT"
 
 	// consts for Secure middleware
 	McsSecureAllowedHosts                    = "MCS_SECURE_ALLOWED_HOSTS"

--- a/restapi/tls.go
+++ b/restapi/tls.go
@@ -1,0 +1,95 @@
+// This file is part of MinIO Orchestrator
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restapi
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+)
+
+var (
+	certDontExists = "File certificate doesn't exists: %s"
+)
+
+func prepareSTSClientTransport() *http.Transport {
+	// This takes github.com/minio/minio/pkg/madmin/transport.go as an example
+	//
+	// DefaultTransport - this default transport is similar to
+	// http.DefaultTransport but with additional param  DisableCompression
+	// is set to true to avoid decompressing content with 'gzip' encoding.
+	DefaultTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 15 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          1024,
+		MaxIdleConnsPerHost:   1024,
+		ResponseHeaderTimeout: 60 * time.Second,
+		IdleConnTimeout:       60 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableCompression:    true,
+	}
+	// If Minio instance is running with TLS enabled and it's using a self-signed certificate
+	// or a certificate issued by a custom certificate authority we prepare a new custom *http.Transport
+	if getMinIOEndpointIsSecure() {
+		caCertFileNames := getMinioServerTLSRootCAs()
+		tlsConfig := &tls.Config{
+			// Can't use SSLv3 because of POODLE and BEAST
+			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+			// Can't use TLSv1.1 because of RC4 cipher usage
+			MinVersion: tls.VersionTLS12,
+		}
+		// If root CAs are configured we save them to the http.Client RootCAs store
+		if len(caCertFileNames) > 0 {
+			certs := x509.NewCertPool()
+			for _, caCert := range caCertFileNames {
+				// Validate certificate exists
+				if FileExists(caCert) {
+					pemData, err := ioutil.ReadFile(caCert)
+					if err != nil {
+						// if there was an error reading pem file stop mcs
+						panic(err)
+					}
+					certs.AppendCertsFromPEM(pemData)
+				} else {
+					// if provided cert filename doesn't exists stop mcs
+					panic(fmt.Sprintf(certDontExists, caCert))
+				}
+			}
+			tlsConfig.RootCAs = certs
+		}
+		DefaultTransport.TLSClientConfig = tlsConfig
+	}
+	return DefaultTransport
+}
+
+// PrepareSTSClient returns an http.Client with custom configurations need it by *credentials.STSAssumeRole
+// custom configurations include skipVerification flag, and root CA certificates
+func PrepareSTSClient() *http.Client {
+	transport := prepareSTSClientTransport()
+	// Return http client with default configuration
+	return &http.Client{
+		Transport: transport,
+	}
+}

--- a/restapi/user_login_test.go
+++ b/restapi/user_login_test.go
@@ -100,7 +100,7 @@ func TestLoginOauth2Auth(t *testing.T) {
 		return nil, errors.New("error")
 	}
 	if _, err := loginOauth2Auth(ctx, identityProvider, mockCode, mockState); funcAssert.Error(err) {
-		funcAssert.Equal("error", err.Error())
+		funcAssert.Equal("an error occurred, please try again", err.Error())
 	}
 }
 
@@ -189,8 +189,8 @@ func Test_getConfiguredRegion(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock()
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getConfiguredRegion(tt.args.client); got != tt.want {
-				t.Errorf("getConfiguredRegion() = %v, want %v", got, tt.want)
+			if got, _ := getConfiguredRegionForLogin(tt.args.client); got != tt.want {
+				t.Errorf("getConfiguredRegionForLogin() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/restapi/utils.go
+++ b/restapi/utils.go
@@ -16,6 +16,8 @@
 
 package restapi
 
+import "os"
+
 // DifferenceArrays returns the elements in `a` that aren't in `b`.
 func DifferenceArrays(a, b []string) []string {
 	mb := make(map[string]struct{}, len(b))
@@ -53,4 +55,13 @@ func UniqueKeys(a []string) []string {
 		}
 	}
 	return list
+}
+
+// FileExists verifies if a file exist on the desired location and its not a folder
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }


### PR DESCRIPTION
This PR adds support to connect MCS to minio instances running TLS with
self-signed certificates or  certificates signed by custom
Certificate Authorities

```
export MCS_MINIO_SERVER_TLS_ROOT_CAS=file1,file2,file3
```

Note: TLS Skip Verification is not supported unless there's a clear need
for it