### PR TITLE
wss for websockets on tls and single page application behavior

### DIFF
--- a/portal-ui/src/screens/Console/Logs/Logs.tsx
+++ b/portal-ui/src/screens/Console/Logs/Logs.tsx
@@ -24,6 +24,7 @@ import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { niceBytes } from "../../../common/utils";
 import Ansi from "ansi-to-react";
 import { isNull, isNullOrUndefined } from "util";
+import { wsProtocol } from "../../../utils/wsUtils";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -79,7 +80,11 @@ const Logs = ({
     const isDev = process.env.NODE_ENV === "development";
     const port = isDev ? "9090" : url.port;
 
-    const c = new W3CWebSocket(`ws://${url.hostname}:${port}/ws/console`);
+    const wsProt = wsProtocol(url.protocol);
+
+    const c = new W3CWebSocket(
+      `${wsProt}://${url.hostname}:${port}/ws/console`
+    );
 
     let interval: any | null = null;
     if (c !== null) {

--- a/portal-ui/src/screens/Console/Trace/Trace.tsx
+++ b/portal-ui/src/screens/Console/Trace/Trace.tsx
@@ -22,6 +22,7 @@ import { traceMessageReceived, traceResetMessages } from "./actions";
 import { TraceMessage } from "./types";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { niceBytes } from "../../../common/utils";
+import { wsProtocol } from "../../../utils/wsUtils";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -61,7 +62,8 @@ const Trace = ({
     const isDev = process.env.NODE_ENV === "development";
     const port = isDev ? "9090" : url.port;
 
-    const c = new W3CWebSocket(`ws://${url.hostname}:${port}/ws/trace`);
+    const wsProt = wsProtocol(url.protocol);
+    const c = new W3CWebSocket(`${wsProt}://${url.hostname}:${port}/ws/trace`);
 
     let interval: any | null = null;
     if (c !== null) {

--- a/portal-ui/src/utils/wsUtils.ts
+++ b/portal-ui/src/utils/wsUtils.ts
@@ -1,0 +1,22 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+export const wsProtocol = (protocol: string): string => {
+  let wsProtocol = "ws";
+  if (protocol == "https:") {
+    wsProtocol = "wss";
+  }
+  return wsProtocol;
+};


### PR DESCRIPTION
Detects `https` and sets the Websocket protocol to `wss`
on asset not found we return `index.html` so the react application can handle 404