### PR TITLE
Changed modal forms to contain scrollbars

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket.tsx
@@ -19,6 +19,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { Button, LinearProgress } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+import { modalBasic } from "../../Common/FormComponents/common/styleLibrary";
 import api from "../../../../common/api";
 import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
@@ -30,7 +31,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 interface IAddBucketProps {
@@ -106,31 +108,29 @@ class AddBucket extends React.Component<IAddBucketProps, IAddBucketState> {
           }}
         >
           <Grid container>
-            {addError !== "" && (
+            <Grid item xs={12} className={classes.formScrollable}>
+              {addError !== "" && (
+                <Grid item xs={12}>
+                  <Typography
+                    component="p"
+                    variant="body1"
+                    className={classes.errorBlock}
+                  >
+                    {addError}
+                  </Typography>
+                </Grid>
+              )}
               <Grid item xs={12}>
-                <Typography
-                  component="p"
-                  variant="body1"
-                  className={classes.errorBlock}
-                >
-                  {addError}
-                </Typography>
+                <InputBoxWrapper
+                  id="bucket-name"
+                  name="bucket-name"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ bucketName: e.target.value });
+                  }}
+                  label="Bucket Name"
+                  value={bucketName}
+                />
               </Grid>
-            )}
-            <Grid item xs={12}>
-              <InputBoxWrapper
-                id="bucket-name"
-                name="bucket-name"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  this.setState({ bucketName: e.target.value });
-                }}
-                label="Bucket Name"
-                value={bucketName}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <br />
-              <br />
             </Grid>
             <Grid item xs={12} className={classes.buttonContainer}>
               <Button

--- a/portal-ui/src/screens/Console/Buckets/ViewBucket/AddEvent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ViewBucket/AddEvent.tsx
@@ -27,6 +27,7 @@ import TableBody from "@material-ui/core/TableBody";
 import Checkbox from "@material-ui/core/Checkbox";
 import Table from "@material-ui/core/Table";
 import { ArnList } from "../types";
+import { modalBasic } from "../../Common/FormComponents/common/styleLibrary";
 import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import SelectWrapper from "../../Common/FormComponents/SelectWrapper/SelectWrapper";
@@ -46,7 +47,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 interface IAddEventProps {
@@ -204,89 +206,91 @@ class AddEvent extends React.Component<IAddEventProps, IAddEventState> {
           }}
         >
           <Grid container>
-            {addError !== "" && (
+            <Grid item xs={12} className={classes.formScrollable}>
+              {addError !== "" && (
+                <Grid item xs={12}>
+                  <Typography
+                    component="p"
+                    variant="body1"
+                    className={classes.errorBlock}
+                  >
+                    {addError}
+                  </Typography>
+                </Grid>
+              )}
               <Grid item xs={12}>
-                <Typography
-                  component="p"
-                  variant="body1"
-                  className={classes.errorBlock}
-                >
-                  {addError}
-                </Typography>
+                <SelectWrapper
+                  onChange={(e: React.ChangeEvent<{ value: unknown }>) => {
+                    this.setState({ arn: e.target.value as string });
+                  }}
+                  id="select-access-policy"
+                  name="select-access-policy"
+                  label={"ARN"}
+                  value={arn}
+                  options={arnValues}
+                />
               </Grid>
-            )}
-            <Grid item xs={12}>
-              <SelectWrapper
-                onChange={(e: React.ChangeEvent<{ value: unknown }>) => {
-                  this.setState({ arn: e.target.value as string });
-                }}
-                id="select-access-policy"
-                name="select-access-policy"
-                label={"ARN"}
-                value={arn}
-                options={arnValues}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <Table size="medium">
-                <TableHead className={classes.minTableHeader}>
-                  <TableRow>
-                    <TableCell>Select</TableCell>
-                    <TableCell>Event</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {events.map(row => (
-                    <TableRow
-                      key={`group-${row.value}`}
-                      onClick={event => handleClick(event, row.value)}
-                    >
-                      <TableCell padding="checkbox">
-                        <Checkbox
-                          value={row.value}
-                          color="primary"
-                          inputProps={{
-                            "aria-label": "secondary checkbox"
-                          }}
-                          onChange={event => handleClick(event, row.value)}
-                          checked={selectedEvents.includes(row.value)}
-                        />
-                      </TableCell>
-                      <TableCell className={classes.wrapCell}>
-                        {row.label}
-                      </TableCell>
+              <Grid item xs={12}>
+                <Table size="medium">
+                  <TableHead className={classes.minTableHeader}>
+                    <TableRow>
+                      <TableCell>Select</TableCell>
+                      <TableCell>Event</TableCell>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </Grid>
-            <Grid item xs={12}>
-              <br />
-            </Grid>
-            <Grid item xs={12}>
-              <InputBoxWrapper
-                id="prefix-input"
-                name="prefix-input"
-                label="Prefix"
-                value={prefix}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  this.setState({ prefix: e.target.value });
-                }}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <InputBoxWrapper
-                id="suffix-input"
-                name="suffix-input"
-                label="Suffix"
-                value={suffix}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  this.setState({ suffix: e.target.value });
-                }}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <br />
+                  </TableHead>
+                  <TableBody>
+                    {events.map(row => (
+                      <TableRow
+                        key={`group-${row.value}`}
+                        onClick={event => handleClick(event, row.value)}
+                      >
+                        <TableCell padding="checkbox">
+                          <Checkbox
+                            value={row.value}
+                            color="primary"
+                            inputProps={{
+                              "aria-label": "secondary checkbox"
+                            }}
+                            onChange={event => handleClick(event, row.value)}
+                            checked={selectedEvents.includes(row.value)}
+                          />
+                        </TableCell>
+                        <TableCell className={classes.wrapCell}>
+                          {row.label}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Grid>
+              <Grid item xs={12}>
+                <br />
+              </Grid>
+              <Grid item xs={12}>
+                <InputBoxWrapper
+                  id="prefix-input"
+                  name="prefix-input"
+                  label="Prefix"
+                  value={prefix}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ prefix: e.target.value });
+                  }}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <InputBoxWrapper
+                  id="suffix-input"
+                  name="suffix-input"
+                  label="Suffix"
+                  value={suffix}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ suffix: e.target.value });
+                  }}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <br />
+              </Grid>
             </Grid>
             <Grid item xs={12} className={classes.buttonContainer}>
               <Button

--- a/portal-ui/src/screens/Console/Buckets/ViewBucket/SetAccessPolicy.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ViewBucket/SetAccessPolicy.tsx
@@ -18,6 +18,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { Button, LinearProgress } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+import { modalBasic } from "../../Common/FormComponents/common/styleLibrary";
 import api from "../../../../common/api";
 import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import SelectWrapper from "../../Common/FormComponents/SelectWrapper/SelectWrapper";
@@ -26,7 +27,8 @@ const styles = (theme: Theme) =>
   createStyles({
     errorBlock: {
       color: "red"
-    }
+    },
+    ...modalBasic
   });
 
 interface ISetAccessPolicyProps {
@@ -105,34 +107,33 @@ class SetAccessPolicy extends React.Component<
           }}
         >
           <Grid container>
-            {addError !== "" && (
+            <Grid item xs={12} className={classes.formScrollable}>
+              {addError !== "" && (
+                <Grid item xs={12}>
+                  <Typography
+                    component="p"
+                    variant="body1"
+                    className={classes.errorBlock}
+                  >
+                    {addError}
+                  </Typography>
+                </Grid>
+              )}
               <Grid item xs={12}>
-                <Typography
-                  component="p"
-                  variant="body1"
-                  className={classes.errorBlock}
-                >
-                  {addError}
-                </Typography>
+                <SelectWrapper
+                  value={accessPolicy}
+                  label="Access Policy"
+                  id="select-access-policy"
+                  name="select-access-policy"
+                  onChange={(e: React.ChangeEvent<{ value: unknown }>) => {
+                    this.setState({ accessPolicy: e.target.value as string });
+                  }}
+                  options={[
+                    { value: "PRIVATE", label: "Private" },
+                    { value: "PUBLIC", label: "Public" }
+                  ]}
+                />
               </Grid>
-            )}
-            <Grid item xs={12}>
-              <SelectWrapper
-                value={accessPolicy}
-                label="Access Policy"
-                id="select-access-policy"
-                name="select-access-policy"
-                onChange={(e: React.ChangeEvent<{ value: unknown }>) => {
-                  this.setState({ accessPolicy: e.target.value as string });
-                }}
-                options={[
-                  { value: "PRIVATE", label: "Private" },
-                  { value: "PUBLIC", label: "Public" }
-                ]}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <br />
             </Grid>
             <Grid item xs={12}>
               <Button

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -33,3 +33,14 @@ export const fieldBasic = {
     marginLeft: 5
   }
 };
+
+export const modalBasic = {
+  formScrollable: {
+    maxHeight: "calc(100vh - 300px)" as const,
+    overflowY: "auto" as const,
+    marginBottom: 25
+  },
+  formSlider: {
+    marginLeft: 0
+  }
+};

--- a/portal-ui/src/screens/Console/Configurations/ConfTargetGeneric.tsx
+++ b/portal-ui/src/screens/Console/Configurations/ConfTargetGeneric.tsx
@@ -17,9 +17,10 @@
 import React, { useEffect, useState } from "react";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
+import { IElementValue, KVField } from "./types";
+import { modalBasic } from "../Common/FormComponents/common/styleLibrary";
 import InputBoxWrapper from "../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import RadioGroupSelector from "../Common/FormComponents/RadioGroupSelector/RadioGroupSelector";
-import { IElementValue, KVField } from "./types";
 import CSVMultiSelector from "../Common/FormComponents/CSVMultiSelector/CSVMultiSelector";
 
 interface IConfGenericProps {
@@ -29,7 +30,10 @@ interface IConfGenericProps {
   classes: any;
 }
 
-const styles = (theme: Theme) => createStyles({});
+const styles = (theme: Theme) =>
+  createStyles({
+    ...modalBasic
+  });
 
 // Function to get defined values,
 //we make this because the backed sometimes don't return all the keys when there is an initial configuration
@@ -137,18 +141,14 @@ const ConfTargetGeneric = ({
 
   return (
     <Grid container>
-      {fieldsElements.map((field, item) => (
-        <React.Fragment key={field.name}>
-          <Grid item xs={12}>
-            {fieldDefinition(field, item)}
-          </Grid>
-        </React.Fragment>
-      ))}
-      <Grid item xs={12}>
-        <br />
-      </Grid>
-      <Grid item xs={12}>
-        <br />
+      <Grid xs={12} item className={classes.formScrollable}>
+        {fieldsElements.map((field, item) => (
+          <React.Fragment key={field.name}>
+            <Grid item xs={12}>
+              {fieldDefinition(field, item)}
+            </Grid>
+          </React.Fragment>
+        ))}
       </Grid>
     </Grid>
   );

--- a/portal-ui/src/screens/Console/Configurations/CustomForms/ConfMySql.tsx
+++ b/portal-ui/src/screens/Console/Configurations/CustomForms/ConfMySql.tsx
@@ -21,13 +21,17 @@ import Grid from "@material-ui/core/Grid";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import RadioGroupSelector from "../../Common/FormComponents/RadioGroupSelector/RadioGroupSelector";
 import { IElementValue } from "../types";
+import { modalBasic } from "../../Common/FormComponents/common/styleLibrary";
 
 interface IConfMySqlProps {
   onChange: (newValue: IElementValue[]) => void;
   classes: any;
 }
 
-const styles = (theme: Theme) => createStyles({});
+const styles = (theme: Theme) =>
+  createStyles({
+    ...modalBasic
+  });
 
 const ConfMySql = ({ onChange, classes }: IConfMySqlProps) => {
   //Local States
@@ -101,7 +105,7 @@ const ConfMySql = ({ onChange, classes }: IConfMySqlProps) => {
   }, [user, dbName, password, port, host, setDsnString, configToDsnString]);
 
   return (
-    <Grid container>
+    <Grid container className={classes.formScrollable}>
       <Grid item xs={12}>
         <FormControlLabel
           control={
@@ -137,6 +141,7 @@ const ConfMySql = ({ onChange, classes }: IConfMySqlProps) => {
             />
           }
           label="Enter DSN String"
+          className={classes.formSlider}
         />
       </Grid>
       {useDsnString ? (
@@ -278,12 +283,6 @@ const ConfMySql = ({ onChange, classes }: IConfMySqlProps) => {
             setComment(e.target.value);
           }}
         />
-      </Grid>
-      <Grid item xs={12}>
-        <br />
-      </Grid>
-      <Grid item xs={12}>
-        <br />
       </Grid>
     </Grid>
   );

--- a/portal-ui/src/screens/Console/Configurations/CustomForms/ConfPostgres.tsx
+++ b/portal-ui/src/screens/Console/Configurations/CustomForms/ConfPostgres.tsx
@@ -22,13 +22,17 @@ import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBo
 import RadioGroupSelector from "../../Common/FormComponents/RadioGroupSelector/RadioGroupSelector";
 import SelectWrapper from "../../Common/FormComponents/SelectWrapper/SelectWrapper";
 import { IElementValue } from "../types";
+import { modalBasic } from "../../Common/FormComponents/common/styleLibrary";
 
 interface IConfPostgresProps {
   onChange: (newValue: IElementValue[]) => void;
   classes: any;
 }
 
-const styles = (theme: Theme) => createStyles({});
+const styles = (theme: Theme) =>
+  createStyles({
+    ...modalBasic
+  });
 
 const ConfPostgres = ({ onChange, classes }: IConfPostgresProps) => {
   //Local States
@@ -166,7 +170,7 @@ const ConfPostgres = ({ onChange, classes }: IConfPostgresProps) => {
   ]);
 
   return (
-    <Grid container>
+    <Grid container className={classes.formScrollable}>
       <Grid item xs={12}>
         <FormControlLabel
           control={
@@ -206,6 +210,7 @@ const ConfPostgres = ({ onChange, classes }: IConfPostgresProps) => {
             />
           }
           label="Enter Connection String"
+          className={classes.formSlider}
         />
       </Grid>
       {useConnectionString ? (
@@ -366,12 +371,6 @@ const ConfPostgres = ({ onChange, classes }: IConfPostgresProps) => {
             setComment(e.target.value);
           }}
         />
-      </Grid>
-      <Grid item xs={12}>
-        <br />
-      </Grid>
-      <Grid item xs={12}>
-        <br />
       </Grid>
     </Grid>
   );

--- a/portal-ui/src/screens/Console/Configurations/CustomForms/EditConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Configurations/CustomForms/EditConfiguration.tsx
@@ -16,20 +16,22 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import get from "lodash/get";
+import { connect } from "react-redux";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { Button, LinearProgress } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import api from "../../../../common/api";
-import { serverNeedsRestart } from "../../../../actions";
-import { connect } from "react-redux";
 import ConfTargetGeneric from "../ConfTargetGeneric";
+import { serverNeedsRestart } from "../../../../actions";
+import { fieldBasic } from "../../Common/FormComponents/common/styleLibrary";
 import { fieldsConfigurations, removeEmptyFields } from "../utils";
 import { IConfigurationElement, IElementValue } from "../types";
 
 const styles = (theme: Theme) =>
   createStyles({
+    ...fieldBasic,
     errorBlock: {
       color: "red"
     },
@@ -157,12 +159,11 @@ const EditConfiguration = ({
             onChange={onValueChange}
             defaultVals={configValues}
           />
-          <Grid item xs={3} className={classes.buttonContainer}>
+          <Grid item xs={12} className={classes.buttonContainer}>
             <Button
               type="submit"
               variant="contained"
               color="primary"
-              fullWidth
               disabled={saving}
             >
               Save

--- a/portal-ui/src/screens/Console/Groups/AddGroup.tsx
+++ b/portal-ui/src/screens/Console/Groups/AddGroup.tsx
@@ -19,6 +19,7 @@ import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { Button, LinearProgress } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
+import { modalBasic } from "../Common/FormComponents/common/styleLibrary";
 import api from "../../../common/api";
 import UsersSelectors from "./UsersSelectors";
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
@@ -51,7 +52,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 const AddGroup = ({
@@ -159,62 +161,61 @@ const AddGroup = ({
     >
       <form noValidate autoComplete="off" onSubmit={setSaving}>
         <Grid container>
-          {addError !== "" && (
-            <Grid item xs={12}>
-              <Typography
-                component="p"
-                variant="body1"
-                className={classes.errorBlock}
-              >
-                {addError}
-              </Typography>
-            </Grid>
-          )}
+          <Grid item xs={12} className={classes.formScrollable}>
+            {addError !== "" && (
+              <Grid item xs={12}>
+                <Typography
+                  component="p"
+                  variant="body1"
+                  className={classes.errorBlock}
+                >
+                  {addError}
+                </Typography>
+              </Grid>
+            )}
 
-          {selectedGroup !== null ? (
-            <React.Fragment>
-              <Grid item xs={12}>
-                <RadioGroupSelector
-                  currentSelection={groupEnabled}
-                  id="group-status"
-                  name="group-status"
-                  label="Status"
-                  onChange={e => {
-                    setGroupEnabled(e.target.value);
-                  }}
-                  selectorOptions={[
-                    { label: "Enabled", value: "enabled" },
-                    { label: "Disabled", value: "disabled" }
-                  ]}
-                />
-              </Grid>
-            </React.Fragment>
-          ) : (
-            <React.Fragment>
-              <Grid item xs={12}>
-                <InputBoxWrapper
-                  id="group-name"
-                  name="group-name"
-                  label="Name"
-                  value={groupName}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setGroupName(e.target.value);
-                  }}
-                />
-              </Grid>
-            </React.Fragment>
-          )}
-          <Grid item xs={12}>
-            <br />
-          </Grid>
-          <Grid item xs={12}>
-            <UsersSelectors
-              selectedUsers={selectedUsers}
-              setSelectedUsers={setSelectedUsers}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <br />
+            {selectedGroup !== null ? (
+              <React.Fragment>
+                <Grid item xs={12}>
+                  <RadioGroupSelector
+                    currentSelection={groupEnabled}
+                    id="group-status"
+                    name="group-status"
+                    label="Status"
+                    onChange={e => {
+                      setGroupEnabled(e.target.value);
+                    }}
+                    selectorOptions={[
+                      { label: "Enabled", value: "enabled" },
+                      { label: "Disabled", value: "disabled" }
+                    ]}
+                  />
+                </Grid>
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                <Grid item xs={12}>
+                  <InputBoxWrapper
+                    id="group-name"
+                    name="group-name"
+                    label="Name"
+                    value={groupName}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setGroupName(e.target.value);
+                    }}
+                  />
+                </Grid>
+              </React.Fragment>
+            )}
+            <Grid item xs={12}>
+              <br />
+            </Grid>
+            <Grid item xs={12}>
+              <UsersSelectors
+                selectedUsers={selectedUsers}
+                setSelectedUsers={setSelectedUsers}
+              />
+            </Grid>
           </Grid>
           <Grid item xs={12} className={classes.buttonContainer}>
             <Button

--- a/portal-ui/src/screens/Console/NotificationEndopoints/AddNotificationEndpoint.tsx
+++ b/portal-ui/src/screens/Console/NotificationEndopoints/AddNotificationEndpoint.tsx
@@ -342,14 +342,14 @@ const AddNotificationEndpoint = ({
             </Grid>
           )}
           <form noValidate onSubmit={submitForm}>
-            {srvComponent}
-
-            <Grid item xs={3} className={classes.buttonContainer}>
+            <Grid item xs={12}>
+              {srvComponent}
+            </Grid>
+            <Grid item xs={12} className={classes.buttonContainer}>
               <Button
                 type="submit"
                 variant="contained"
                 color="primary"
-                fullWidth
                 disabled={saving}
               >
                 Save

--- a/portal-ui/src/screens/Console/Policies/AddPolicy.tsx
+++ b/portal-ui/src/screens/Console/Policies/AddPolicy.tsx
@@ -24,6 +24,7 @@ import api from "../../../common/api";
 import "codemirror/lib/codemirror.css";
 import "codemirror/theme/material.css";
 import { Policy } from "./types";
+import { modalBasic } from "../Common/FormComponents/common/styleLibrary";
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 
@@ -43,7 +44,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 interface IAddPolicyProps {
@@ -131,51 +133,50 @@ class AddPolicy extends React.Component<IAddPolicyProps, IAddPolicyState> {
           }}
         >
           <Grid container>
-            {addError !== "" && (
+            <Grid item xs={12} className={classes.formScrollable}>
+              {addError !== "" && (
+                <Grid item xs={12}>
+                  <Typography
+                    component="p"
+                    variant="body1"
+                    className={classes.errorBlock}
+                  >
+                    {addError}
+                  </Typography>
+                </Grid>
+              )}
               <Grid item xs={12}>
-                <Typography
-                  component="p"
-                  variant="body1"
-                  className={classes.errorBlock}
-                >
-                  {addError}
-                </Typography>
+                <InputBoxWrapper
+                  id="policy-name"
+                  name="policy-name"
+                  label="Policy Name"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ policyName: e.target.value });
+                  }}
+                  value={policyName}
+                  disabled={!!policyEdit}
+                />
               </Grid>
-            )}
-            <Grid item xs={12}>
-              <InputBoxWrapper
-                id="policy-name"
-                name="policy-name"
-                label="Policy Name"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  this.setState({ policyName: e.target.value });
-                }}
-                value={policyName}
-                disabled={!!policyEdit}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <br />
-            </Grid>
-            <Grid item xs={12}>
-              <CodeMirror
-                className={classes.codeMirror}
-                value={
-                  policyEdit
-                    ? JSON.stringify(JSON.parse(policyEdit.policy), null, 4)
-                    : ""
-                }
-                options={{
-                  mode: "javascript",
-                  lineNumbers: true
-                }}
-                onChange={(editor, data, value) => {
-                  this.setState({ policyDefinition: value });
-                }}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <br />
+              <Grid item xs={12}>
+                <br />
+              </Grid>
+              <Grid item xs={12}>
+                <CodeMirror
+                  className={classes.codeMirror}
+                  value={
+                    policyEdit
+                      ? JSON.stringify(JSON.parse(policyEdit.policy), null, 4)
+                      : ""
+                  }
+                  options={{
+                    mode: "javascript",
+                    lineNumbers: true
+                  }}
+                  onChange={(editor, data, value) => {
+                    this.setState({ policyDefinition: value });
+                  }}
+                />
+              </Grid>
             </Grid>
             {!policyEdit && (
               <Grid item xs={12} className={classes.buttonContainer}>

--- a/portal-ui/src/screens/Console/Users/AddToGroup.tsx
+++ b/portal-ui/src/screens/Console/Users/AddToGroup.tsx
@@ -18,6 +18,7 @@ import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { Button, LinearProgress } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
+import { modalBasic } from "../Common/FormComponents/common/styleLibrary";
 import api from "../../../common/api";
 import GroupsSelectors from "./GroupsSelectors";
 import Title from "../../../common/Title";
@@ -43,7 +44,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 const AddToGroup = ({
@@ -106,35 +108,34 @@ const AddToGroup = ({
     >
       <form noValidate autoComplete="off" onSubmit={setSaving}>
         <Grid container>
-          {updatingError !== "" && (
-            <Grid item xs={12}>
-              <Typography
-                component="p"
-                variant="body1"
-                className={classes.errorBlock}
-              >
-                {updatingError}
-              </Typography>
-            </Grid>
-          )}
+          <Grid item xs={12} className={classes.formScrollable}>
+            {updatingError !== "" && (
+              <Grid item xs={12}>
+                <Typography
+                  component="p"
+                  variant="body1"
+                  className={classes.errorBlock}
+                >
+                  {updatingError}
+                </Typography>
+              </Grid>
+            )}
 
-          <Grid item xs={12}>
-            <Title>Users to be altered</Title>
-          </Grid>
-          <Grid item xs={12}>
-            {checkedUsers.join(", ")}
-          </Grid>
-          <Grid item xs={12}>
-            <br />
-          </Grid>
-          <Grid item xs={12}>
-            <GroupsSelectors
-              selectedGroups={selectedGroups}
-              setSelectedGroups={setSelectedGroups}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <br />
+            <Grid item xs={12}>
+              <Title>Users to be altered</Title>
+            </Grid>
+            <Grid item xs={12}>
+              {checkedUsers.join(", ")}
+            </Grid>
+            <Grid item xs={12}>
+              <br />
+            </Grid>
+            <Grid item xs={12}>
+              <GroupsSelectors
+                selectedGroups={selectedGroups}
+                setSelectedGroups={setSelectedGroups}
+              />
+            </Grid>
           </Grid>
           <Grid item xs={12} className={classes.buttonContainer}>
             <Button

--- a/portal-ui/src/screens/Console/Users/AddUser.tsx
+++ b/portal-ui/src/screens/Console/Users/AddUser.tsx
@@ -19,8 +19,9 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { Button, LinearProgress } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
-import api from "../../../common/api";
+import { modalBasic } from "../Common/FormComponents/common/styleLibrary";
 import { User } from "./types";
+import api from "../../../common/api";
 import GroupsSelectors from "./GroupsSelectors";
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
@@ -39,7 +40,8 @@ const styles = (theme: Theme) =>
     },
     buttonContainer: {
       textAlign: "right"
-    }
+    },
+    ...modalBasic
   });
 
 interface IAddUserContentProps {
@@ -204,68 +206,67 @@ class AddUserContent extends React.Component<
             }}
           >
             <Grid container>
-              {addError !== "" && (
-                <Grid item xs={12}>
-                  <Typography
-                    component="p"
-                    variant="body1"
-                    className={classes.errorBlock}
-                  >
-                    {addError}
-                  </Typography>
-                </Grid>
-              )}
+              <Grid item xs={12} className={classes.formScrollable}>
+                {addError !== "" && (
+                  <Grid item xs={12}>
+                    <Typography
+                      component="p"
+                      variant="body1"
+                      className={classes.errorBlock}
+                    >
+                      {addError}
+                    </Typography>
+                  </Grid>
+                )}
 
-              <InputBoxWrapper
-                id="accesskey-input"
-                name="accesskey-input"
-                label="Access Key"
-                value={accessKey}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  this.setState({ accessKey: e.target.value });
-                }}
-                disabled={selectedUser !== null}
-              />
-
-              {selectedUser !== null ? (
-                <RadioGroupSelector
-                  currentSelection={enabled}
-                  id="user-status"
-                  name="user-status"
-                  label="Status"
-                  onChange={e => {
-                    this.setState({ enabled: e.target.value });
-                  }}
-                  selectorOptions={[
-                    { label: "Enabled", value: "enabled" },
-                    { label: "Disabled", value: "disabled" }
-                  ]}
-                />
-              ) : (
                 <InputBoxWrapper
-                  id="standard-multiline-static"
-                  name="standard-multiline-static"
-                  label="Secret Key"
-                  type="password"
-                  value={secretKey}
+                  id="accesskey-input"
+                  name="accesskey-input"
+                  label="Access Key"
+                  value={accessKey}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    this.setState({ secretKey: e.target.value });
+                    this.setState({ accessKey: e.target.value });
                   }}
-                  autoComplete="current-password"
+                  disabled={selectedUser !== null}
                 />
-              )}
-              <Grid item xs={12}>
-                <GroupsSelectors
-                  selectedGroups={selectedGroups}
-                  setSelectedGroups={(elements: string[]) => {
-                    this.setState({
-                      selectedGroups: elements
-                    });
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <br />
+
+                {selectedUser !== null ? (
+                  <RadioGroupSelector
+                    currentSelection={enabled}
+                    id="user-status"
+                    name="user-status"
+                    label="Status"
+                    onChange={e => {
+                      this.setState({ enabled: e.target.value });
+                    }}
+                    selectorOptions={[
+                      { label: "Enabled", value: "enabled" },
+                      { label: "Disabled", value: "disabled" }
+                    ]}
+                  />
+                ) : (
+                  <InputBoxWrapper
+                    id="standard-multiline-static"
+                    name="standard-multiline-static"
+                    label="Secret Key"
+                    type="password"
+                    value={secretKey}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      this.setState({ secretKey: e.target.value });
+                    }}
+                    autoComplete="current-password"
+                  />
+                )}
+                <Grid item xs={12}>
+                  <GroupsSelectors
+                    selectedGroups={selectedGroups}
+                    setSelectedGroups={(elements: string[]) => {
+                      this.setState({
+                        selectedGroups: elements
+                      });
+                    }}
+                  />
+                </Grid>
               </Grid>
               <Grid item xs={12} className={classes.buttonContainer}>
                 <Button


### PR DESCRIPTION
fixes #110 

## What does this do?
Changed modal forms to contain scrollbars where the inputs are, so this way the titles and buttons get always visible.

## How to test
Go into long forms and check that all of them contain a scrollbar in the inputs section. Title & buttons must be always visible
You can shrink the window to check that the behavior also happens with small screens

![Screen Shot 2020-05-11 at 11 57 18 PM](https://user-images.githubusercontent.com/33497058/81640044-2e305480-93e3-11ea-94bb-323a1fde0bb2.png)
 