### PR TITLE
Added flag for operator only features

### DIFF
--- a/pkg/acl/config.go
+++ b/pkg/acl/config.go
@@ -1,0 +1,29 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package acl
+
+import (
+	"strings"
+
+	"github.com/minio/minio/pkg/env"
+)
+
+// GetOperatorOnly gets mcs operator mode status set on env variable
+//or default one
+func GetOperatorOnly() string {
+	return strings.ToLower(env.Get(McsOperatorOnly, "off"))
+}

--- a/pkg/acl/const.go
+++ b/pkg/acl/const.go
@@ -1,0 +1,21 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package acl
+
+const (
+	McsOperatorOnly = "MCS_OPERATOR_ONLY"
+)

--- a/portal-ui/src/screens/Console/Clusters/ListClusters/ListClusters.tsx
+++ b/portal-ui/src/screens/Console/Clusters/ListClusters/ListClusters.tsx
@@ -192,7 +192,6 @@ const ListClusters = ({ classes }: IClustersList) => {
           </Button>
         </Grid>
         <Grid item xs={12}>
-          REMOVE THIS:: <Link to={"/clusters/demoCluster"}>Test</Link>
           <br />
         </Grid>
         <Grid item xs={12}>

--- a/portal-ui/src/screens/Console/Menu.tsx
+++ b/portal-ui/src/screens/Console/Menu.tsx
@@ -145,7 +145,6 @@ class Menu extends React.Component<MenuProps> {
         to: "/service-accounts",
         name: "Service Accounts",
         icon: <RoomServiceIcon />,
-        forceDisplay: true,
       },
       {
         type: "item",
@@ -244,7 +243,6 @@ class Menu extends React.Component<MenuProps> {
         to: "/clusters",
         name: "Clusters",
         icon: <StorageIcon />,
-        forceDisplay: true,
       },
       {
         type: "divider",

--- a/restapi/user_session.go
+++ b/restapi/user_session.go
@@ -53,6 +53,7 @@ func getSessionResponse(sessionID string) (*models.SessionResponse, error) {
 		log.Println("error getting claims from JWT", err)
 		return nil, errorGenericInvalidSession
 	}
+
 	sessionResp := &models.SessionResponse{
 		Pages:  acl.GetAuthorizedEndpoints(claims.Actions),
 		Status: models.SessionResponseStatusOk,


### PR DESCRIPTION
fixes #143 

## What does this do?
Added flag to only enable operator endpoints / links in mcs

## How to test

- Enable MCS_OPERATOR_ONLY flag as "on" before running server
-  Run server as usual

![Screen Shot 2020-05-26 at 3 26 04 PM](https://user-images.githubusercontent.com/33497058/82948795-15d64300-9f68-11ea-95fe-41355282e5b8.png)
![Screen Shot 2020-05-26 at 3 25 06 PM](https://user-images.githubusercontent.com/33497058/82948799-17077000-9f68-11ea-85de-5bd417c34dfa.png)
