### PR TITLE
Proxy API For Mkube

### DIFF
--- a/restapi/config.go
+++ b/restapi/config.go
@@ -228,3 +228,8 @@ func getSecureFeaturePolicy() string {
 func getSecureExpectCTHeader() string {
 	return env.Get(McsSecureExpectCTHeader, "")
 }
+
+// getM3Host returns the hostname of mkube
+func getM3Host() string {
+	return env.Get(McsM3Host, "http://m3:8787")
+}

--- a/restapi/configure_mcs.go
+++ b/restapi/configure_mcs.go
@@ -164,6 +164,9 @@ func FileServerMiddleware(next http.Handler) http.Handler {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/ws"):
 			serveWS(w, r)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/clusters"):
+			client := &http.Client{}
+			serverMkube(client, w, r)
 		case strings.HasPrefix(r.URL.Path, "/api"):
 			next.ServeHTTP(w, r)
 		default:

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -49,4 +49,5 @@ const (
 	McsSecureReferrerPolicy                  = "MCS_SECURE_REFERRER_POLICY"
 	McsSecureFeaturePolicy                   = "MCS_SECURE_FEATURE_POLICY"
 	McsSecureExpectCTHeader                  = "MCS_SECURE_EXPECT_CT_HEADER"
+	McsM3Host                                = "MCS_M3_HOSTNAME"
 )

--- a/restapi/mkube.go
+++ b/restapi/mkube.go
@@ -1,0 +1,63 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restapi
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apiErrors "github.com/go-openapi/errors"
+)
+
+// serverMkube handles calls for mkube
+func serverMkube(client *http.Client, w http.ResponseWriter, req *http.Request) {
+	// destination of the request, the mkube server
+	targetURL := fmt.Sprintf("%s%s", getM3Host(), req.URL.String())
+
+	// set the HTTP method, url, and m3Req body
+	m3Req, err := http.NewRequest(req.Method, targetURL, req.Body)
+	if err != nil {
+		apiErrors.ServeError(w, req, err)
+		return
+	}
+
+	// set the m3Req headers
+	m3Req.Header = req.Header
+	resp, err := client.Do(m3Req)
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			apiErrors.ServeError(w, req, errors.New("service M3 is not available"))
+			return
+		}
+		apiErrors.ServeError(w, req, err)
+		return
+	}
+	defer resp.Body.Close()
+	w.Header().Add("Content-Type", resp.Header.Get("Content-Type"))
+	// Write the m3 response to the response writer
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		w.Write(scanner.Bytes())
+	}
+	if err := scanner.Err(); err != nil {
+		apiErrors.ServeError(w, req, err)
+	}
+
+}

--- a/restapi/mkube_test.go
+++ b/restapi/mkube_test.go
@@ -1,0 +1,119 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restapi
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// RoundTripFunc .
+type RoundTripFunc func(req *http.Request) (*http.Response, error)
+
+// RoundTrip .
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}
+
+func Test_serverMkube(t *testing.T) {
+
+	OKclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	badClient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 500,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`NOTOK`)),
+			Header:     make(http.Header),
+		}, errors.New("something wrong")
+	})
+
+	refusedClient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 500,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`NOTOK`)),
+			Header:     make(http.Header),
+		}, errors.New("connection refused")
+	})
+
+	testURL, _ := url.Parse("/api/v1/clusters")
+	type args struct {
+		client   *http.Client
+		recorder *httptest.ResponseRecorder
+		req      *http.Request
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name: "Successful request",
+			args: args{
+				client:   OKclient,
+				recorder: httptest.NewRecorder(),
+				req:      &http.Request{URL: testURL},
+			},
+			wantCode: 200,
+		},
+		{
+			name: "Unsuccessful request",
+			args: args{
+				client:   badClient,
+				recorder: httptest.NewRecorder(),
+				req:      &http.Request{URL: testURL},
+			},
+			wantCode: 500,
+		},
+		{
+			name: "refused request",
+			args: args{
+				client:   refusedClient,
+				recorder: httptest.NewRecorder(),
+				req:      &http.Request{URL: testURL},
+			},
+			wantCode: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverMkube(tt.args.client, tt.args.recorder, tt.args.req)
+			resp := tt.args.recorder.Result()
+			if resp.StatusCode != tt.wantCode {
+				t.Errorf("Invalid code returned")
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Proxies the requests for `/api/v1/clusters` to an mkube endpoint